### PR TITLE
attach to syncWithoutDetaching

### DIFF
--- a/app/Services/ThemoviedbParserService.php
+++ b/app/Services/ThemoviedbParserService.php
@@ -63,8 +63,8 @@ class ThemoviedbParserService implements Parser
             
             foreach ($serial['genre_ids'] as $genre => $id) {
                 $category = Category::where('tmdb_id', $id)->get('id');
-                //dd($category);
-                $new_serial->categories()->attach($category, ['serial_id' => $new_serial['id']]);
+                
+                $new_serial->categories()->syncWithoutDetaching($category, ['serial_id' => $new_serial['id']]);
             }
         }
     }


### PR DESCRIPTION
BugFixing: attach - create new rows, syncWithoutDetaching - sync the intermediate tables with a list of IDs without detaching.