### PR TITLE
fix composer.lock

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -61,7 +61,6 @@
                 "source": "https://github.com/asm89/stack-cors/tree/v2.0.5"
             },
             "time": "2022-01-03T15:27:13+00:00"              
-            },
         },
         {
             "name": "brick/math",


### PR DESCRIPTION
Лишняя скобка не позволяла запустить проект на хероку